### PR TITLE
refactor(chart): CoinChart import 방식 및 clamp 로직 개선

### DIFF
--- a/src/components/charts/CoinChart.tsx
+++ b/src/components/charts/CoinChart.tsx
@@ -1,13 +1,13 @@
 "use client";
 
 import {
-  CandlestickSeries,
   CandlestickData,
+  CandlestickSeries,
   createChart,
   IChartApi,
   ISeriesApi,
-  Time,
   PriceScaleMode,
+  Time,
 } from "lightweight-charts";
 import { useEffect, useRef } from "react";
 
@@ -43,15 +43,23 @@ export default function CoinChart({
   const clampCandle = (
     prevClose: number | null,
     candle: CandlestickData,
-    pct = 0.25
+    pct = 0.05
   ): CandlestickData => {
     const baseline = prevClose ?? candle.open ?? candle.close;
     const range = [baseline * (1 - pct), baseline * (1 + pct)];
 
     const open = Math.min(Math.max(candle.open, range[0]), range[1]);
     const close = Math.min(Math.max(candle.close, range[0]), range[1]);
-    const high = Math.max(open, close, Math.min(Math.max(candle.high, range[0]), range[1]));
-    const low = Math.min(open, close, Math.min(Math.max(candle.low, range[0]), range[1]));
+    const high = Math.max(
+      open,
+      close,
+      Math.min(Math.max(candle.high, range[0]), range[1])
+    );
+    const low = Math.min(
+      open,
+      close,
+      Math.min(Math.max(candle.low, range[0]), range[1])
+    );
 
     return { time: candle.time, open, high, low, close };
   };
@@ -66,7 +74,7 @@ export default function CoinChart({
         low: Number(d[3]),
         close: Number(d[4]),
       };
-      const cleanedCandle = clampCandle(lastClose, candle);
+      const cleanedCandle = clampCandle(lastClose, candle, 0.005);
       lastClose = cleanedCandle.close;
       return cleanedCandle;
     });
@@ -88,15 +96,17 @@ export default function CoinChart({
       timeScale: { timeVisible: true, secondsVisible: false },
     });
 
-    chart.priceScale("right").applyOptions({ mode: PriceScaleMode.Logarithmic });
+    chart
+      .priceScale("right")
+      .applyOptions({ mode: PriceScaleMode.Logarithmic });
 
     const series = chart.addSeries(CandlestickSeries, {
-      upColor: "#16a34a",
-      borderUpColor: "#16a34a",
-      wickUpColor: "#16a34a",
-      downColor: "#dc2626",
-      borderDownColor: "#dc2626",
-      wickDownColor: "#dc2626",
+      upColor: "#dc2626",
+      borderUpColor: "#dc2626",
+      wickUpColor: "#dc2626",
+      downColor: "#3c47e1",
+      borderDownColor: "#3c47e1",
+      wickDownColor: "#3c47e1",
     });
 
     series.setData(formattedData);


### PR DESCRIPTION
## 작업 내용
- CoinChart 컴포넌트에서 import 구문 정리
- clampCandle 기본 범위값 조정 (0.25 → 0.05, formatInitialData에서 0.005 적용)
- 차트 렌더링 시 wick 값이 비정상적으로 길게 표시되는 문제 완화

## 작업 이유
- import 구문을 정리하여 코드 가독성 및 유지보수성을 개선
- clamp 로직을 현실적인 범위로 조정하여 캔들 차트 표시가 더 자연스럽도록 수정

## 변경 전/후
- 변경 전: wick이 지나치게 길어져 차트 가독성이 떨어짐
- 변경 후: wick이 데이터 범위 안에서 정상적으로 표시됨

## 테스트
- 로컬 환경에서 BTCUSDT 차트 데이터로 확인 완료
- 실시간 WebSocket 업데이트 정상 동작 확인
